### PR TITLE
feat: add AI skills section to /stuff page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -52,6 +52,8 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("css");
   eleventyConfig.addPassthroughCopy("js");
   eleventyConfig.addPassthroughCopy("CNAME");
+  eleventyConfig.addPassthroughCopy("stuff/skills");
+  eleventyConfig.ignores.add("./stuff/skills/**/*.md");
   /* Markdown Plugins */
   let markdownIt = require("markdown-it");
   let markdownItAnchor = require("markdown-it-anchor");

--- a/stuff/index.md
+++ b/stuff/index.md
@@ -48,4 +48,18 @@ But here some list :
 - Everything Aaron Mahnke, [Lore](https://www.lorepodcast.com/), and others podcast he do.
 - And all show on the [Changelog Podcast](https://changelog.com/)
 
+## AI
+
+I've been experimenting with AI-powered workflows. Here are some skills I use with AI coding agents like OpenCode and Claude Code. Each skill is a prompt template that tells the AI how to help with a specific task.
+
+### AI Skills
+
+- [Create a Resume](skills/create-a-resume/SKILL.md) — Tailor your CV PDF to a job description and get a polished one-page resume back.
+- [Code Review](skills/code-review/SKILL.md) — Get fast, actionable feedback on diffs and pull requests.
+
+### Tools I Use
+
+- **[OpenCode](https://github.com/nicepkg/opencode)** — Terminal-first AI coding agent with multi-model support.
+- **[Paseo](https://paseo.sh/)** — Agent orchestration for OpenCode, spinning up subagents for research, building, and review.
+
 And I think just that other random stuff maybe I'll, update again later.

--- a/stuff/skills/code-review/SKILL.md
+++ b/stuff/skills/code-review/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: code-review
+description: Get AI-powered code review feedback. Paste a diff or snippet and receive actionable, concise review comments.
+tags:
+  - development
+  - quality
+---
+
+# Code Review
+
+## Goal
+Provide fast, actionable code review feedback on diffs or snippets.
+
+## Instructions for AI
+1. Read the code or diff thoroughly.
+2. Flag bugs, security issues, performance problems, and style inconsistencies.
+3. Suggest concrete fixes, not vague advice.
+4. Be concise — one line per issue: location, problem, fix.
+5. Skip nitpicks that don't affect correctness or maintainability.
+
+## Example Prompt
+> "Review this PR: [paste diff]. It adds a new API endpoint for user settings."
+
+## Output
+A numbered list of review comments, each with file/line, problem description, and suggested fix.

--- a/stuff/skills/create-a-resume/SKILL.md
+++ b/stuff/skills/create-a-resume/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: create-a-resume
+description: Tailor a resume PDF from your existing CV and a target job description. Give it your CV path and JD link or text, get a polished PDF back.
+tags:
+  - productivity
+  - career
+---
+
+# Create a Resume
+
+## Goal
+Read your existing CV (PDF), compare against a job description, and produce a tailored one-page PDF resume that highlights what matters for that role.
+
+## Usage
+
+```
+/create-a-resume
+
+Job Description: <url or text>
+CV Location: <path to your PDF>
+```
+
+- **Job Description** — a URL (the AI will fetch and extract it using browser/web tools) or paste the text directly.
+- **CV Location** — local file path to your current CV in PDF format.
+
+## Instructions for AI
+1. Read the CV PDF at the given path and extract all content.
+2. If a JD URL is provided, fetch and extract the job description using browser or web tools.
+3. Map the CV content to the JD: identify matching skills, experience, and projects.
+4. Structure the resume into: **Summary**, **Experience**, **Skills**, **Projects**.
+5. Reorder and rephrase bullet points to highlight JD-relevant impact first.
+
+## Rules
+- **Keep it one page.** Cut anything not relevant to this specific role.
+- **Be concise.** Use short, punchy bullet points with action verbs.
+- **Impact-first.** Quantify where real numbers exist. Never invent metrics.
+- **Honest, but sell.** Don't overhype or fabricate. Present genuine experience in the best light aligned to the JD.
+- **Match the JD language.** Use the same terminology the job description uses (e.g., if they say "design systems", don't say "component library").
+
+## Output
+A PDF file saved next to the original CV with `-tailored` suffix (e.g., `cv-tailored.pdf`).


### PR DESCRIPTION
Add create-a-resume and code-review skills as SKILL.md files. Add OpenCode and Paseo tools to the AI section.
Configure Eleventy to passthrough copy skills directory.